### PR TITLE
Enable new navigation flow for axe-logs and configurability of auto-follow in log-groups buffer

### DIFF
--- a/axe-logs.el
+++ b/axe-logs.el
@@ -95,12 +95,12 @@ AWS API params."
 			   (cons "startTime" start-time)))))
 
 ;;;###autoload
-(defun axe-logs-describe-log-groups (prefix)
+(cl-defun axe-logs-describe-log-groups (prefix &key (auto-follow t))
   "Opens a new buffer and displays all log groups.
 If PREFIX is not nil, it is used to filter by log group name
 prefix.  May result in multiple API calls.  If that is the case
 then subsequent results may take some time to load and
-displayed."
+displayed.  AUTO-FOLLOW can be used to control the auto-follow behaviour."
   (interactive "sPrefix: ")
   (let ((prefix (if (equal "" prefix) nil prefix))
 	(limit ()))
@@ -124,7 +124,7 @@ displayed."
        map)
      (cl-function (lambda (&key data &allow-other-keys)
 		    (alist-get 'nextToken data)))
-     :auto-follow t
+     :auto-follow auto-follow
      :auto-follow-delay 0.1)))
 
 ;;;###autoload


### PR DESCRIPTION
First of I would like to say, this is a really cool project that has some very cool features.

* Make auto-follow a default keyed param to `axe-logs-describe-log-groups` to be able to configure the variable to avoid fetching the world if working on a account with a large set of log groups
* Enable workflow that mirrors the way I guess most people get logs from CloudWatch log-groups view -> log-streams view -> log-stream view

I took the liberty of binding <C-Return> to follow a log "link" I don't know if this matches your vision. If not I'll be happy to implement what is need to make that work.